### PR TITLE
Fix ExcludeGit Parameter description

### DIFF
--- a/templates/git2s3.template.yaml
+++ b/templates/git2s3.template.yaml
@@ -115,7 +115,7 @@ Parameters:
     Type: String
     Default: ''
   ExcludeGit:
-    Description: Choose False to omit the .git directory from the Git repository .zip file.
+    Description: Choose True to omit the .git directory from the Git repository .zip file.
     Type: String
     Default: 'True'
     AllowedValues: ['True', 'False']


### PR DESCRIPTION
Hi,

The template has a wrong description for the ExcludeGit parameter. In fact, setting it to True means the .git directory is excluded.