### PR TITLE
Update git2s3.template.yaml - python3.7 not supported

### DIFF
--- a/templates/git2s3.template.yaml
+++ b/templates/git2s3.template.yaml
@@ -220,7 +220,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination.
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Role: !GetAtt 'CopyZipsRole.Arn'
       Timeout: 240
       Code:


### PR DESCRIPTION
CopyZipsFunction fails with the following message:

`Resource handler returned message: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: xxx)" (RequestToken: xxx, HandlerErrorCode: InvalidRequest)`